### PR TITLE
matchUpdateTypes including major updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,7 @@
   "packageRules": [
     {
       "matchPackagePatterns": [ "flake8", "pycodestyle", "pyflakes" ],
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest", "major"],
       "groupName": "linter"
     }
   ],


### PR DESCRIPTION
The configuration introduced in #30 was not adequate resulting in #31 and #32.

Now, the configuration include major releases hoping to include flake8 inside the linter group.